### PR TITLE
aligned_address: Ensure addr is a number when doing bit.band

### DIFF
--- a/bitmap.lua
+++ b/bitmap.lua
@@ -479,7 +479,7 @@ local function aligned_address(addr, align)
 	end
 	assert(align >= 2)
 	assert(band(align, align - 1) == 0) --must be power-of-two
-	return band(addr + align - 1, bnot(align - 1)), align
+	return band(tonumber(addr) + align - 1, bnot(align - 1)), align
 end
 
 local voidp_ct = ffi.typeof'void*'


### PR DESCRIPTION
I was getting the following error when trying to run the `boxblur` demo (Linux x64):

```
./bitmap.lua:483: bad argument #1 to 'band' (number expected, got cdata)
stack traceback:
	[C]: in function 'band'
	./bitmap.lua:483: in function 'aligned_address'
	./bitmap.lua:489: in function 'aligned_pointer'
	./bitmap.lua:534: in function 'new'
	./boxblur.lua:72: in function 'new'
```

This change fixes it.